### PR TITLE
separate utp and tcp tests

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,6 +2,7 @@
 
 var minimist = require('minimist')
 var argv = minimist(process.argv.slice(2))
+
 require('.')({
   port: argv.port,
   id: argv._[0]

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "crypto": "0.0.3",
     "datland-swarm-defaults": "^1.0.2",
+    "debug": "^2.6.1",
     "discovery-swarm": "^4.0.2",
     "dns-discovery": "^5.3.4",
     "minimist": "^1.2.0",


### PR DESCRIPTION

* Run two test with the public peer (test `utp` and `tcp` separately)
* Less logging output
* Add debug for remaining output
* Make failure clearer